### PR TITLE
Declare utf8 charset in jade file

### DIFF
--- a/chrome/views/background.jade
+++ b/chrome/views/background.jade
@@ -2,4 +2,5 @@ doctype html
 
 html
   head
+    meta(charset='utf-8')
     script(src=env == 'prod' ? '/js/background.bundle.js' : 'http://localhost:3000/js/background.bundle.js')


### PR DESCRIPTION
According to the HTML5 standard the charset has to be declared. Either by the HTTP Header, Byte Order Mark or a `<meta charset=` entry.

https://www.w3.org/TR/html5-diff/#character-encoding